### PR TITLE
replaced deprecated fromstring() with frombuffer()

### DIFF
--- a/create_lmdb_dataset.py
+++ b/create_lmdb_dataset.py
@@ -11,7 +11,7 @@ import numpy as np
 def checkImageIsValid(imageBin):
     if imageBin is None:
         return False
-    imageBuf = np.fromstring(imageBin, dtype=np.uint8)
+    imageBuf = np.frombuffer(imageBin, dtype=np.uint8)
     img = cv2.imdecode(imageBuf, cv2.IMREAD_GRAYSCALE)
     imgH, imgW = img.shape[0], img.shape[1]
     if imgH * imgW == 0:


### PR DESCRIPTION
I kept getting a deprection warning:

> DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead imageBuf = np.fromstring(imageBin, dtype=np.uint8)

Replacing `fromstring()` with `frombuffer()` fixes the issue.