### PR TITLE
Correct demo.py error when running with CTC

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -57,7 +57,7 @@ def demo(opt):
                 # Select max probabilty (greedy decoding) then decode index to character
                 preds_size = torch.IntTensor([preds.size(1)] * batch_size)
                 _, preds_index = preds.max(2)
-                preds_index = preds_index.view(-1)
+                # preds_index = preds_index.view(-1)
                 preds_str = converter.decode(preds_index.data, preds_size.data)
 
             else:

--- a/demo.py
+++ b/demo.py
@@ -58,7 +58,7 @@ def demo(opt):
                 preds_size = torch.IntTensor([preds.size(1)] * batch_size)
                 _, preds_index = preds.max(2)
                 # preds_index = preds_index.view(-1)
-                preds_str = converter.decode(preds_index.data, preds_size.data)
+                preds_str = converter.decode(preds_index, preds_size)
 
             else:
                 preds = model(image, text_for_pred, is_train=False)


### PR DESCRIPTION
```python
preds_index = preds_index.view(-1)
```
is not need to decode the `preds`. It makes each word to decode into one. So I comment out that line.


And Since PyTorch version 0.4.0, `Variable` and `Tensor` have been merged. So at this line,
```python
preds_str = converter.decode(preds_index.data, preds_size.data)
``` 
there is no more need to use `.data`. There is no problem if `.data` is deleted. Therefore, I modify `preds_index.data` to `preds_index` and `preds_size.data` to `preds_size`.