### PR TITLE
add Baidu warpctc option to reproduce CTC results of our paper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Based on this framework, we recorded the 1st place of [ICDAR2013 focused scene t
 The difference between our paper and ICDAR challenge is summarized [here](https://github.com/clovaai/deep-text-recognition-benchmark/issues/13).
 
 ## Updates
+**Aug 3, 2020**: added [guideline to use Baidu warpctc](https://github.com/clovaai/deep-text-recognition-benchmark/pull/209) which reproduces CTC results of our paper. <br>
 **Dec 27, 2019**: added [FLOPS](https://github.com/clovaai/deep-text-recognition-benchmark/issues/125) in our paper, and minor updates such as log_dataset.txt and [ICDAR2019-NormalizedED](https://github.com/clovaai/deep-text-recognition-benchmark/blob/86451088248e0490ff8b5f74d33f7d014f6c249a/test.py#L139-L165). <br>
 **Oct 22, 2019**: added [confidence score](https://github.com/clovaai/deep-text-recognition-benchmark/issues/82), and arranged the output form of training logs. <br>
 **Jul 31, 2019**: The paper is accepted at International Conference on Computer Vision (ICCV), Seoul 2019, as an oral talk. <br>

--- a/train.py
+++ b/train.py
@@ -12,7 +12,7 @@ import torch.optim as optim
 import torch.utils.data
 import numpy as np
 
-from utils import CTCLabelConverter, AttnLabelConverter, Averager
+from utils import CTCLabelConverter, CTCLabelConverterForBaiduWarpctc, AttnLabelConverter, Averager
 from dataset import hierarchical_dataset, AlignCollate, Batch_Balanced_Dataset
 from model import Model
 from test import validation
@@ -45,7 +45,10 @@ def train(opt):
     
     """ model configuration """
     if 'CTC' in opt.Prediction:
-        converter = CTCLabelConverter(opt.character)
+        if opt.baiduCTC:
+            converter = CTCLabelConverterForBaiduWarpctc(opt.character)
+        else:
+            converter = CTCLabelConverter(opt.character)
     else:
         converter = AttnLabelConverter(opt.character)
     opt.num_class = len(converter.character)
@@ -86,7 +89,12 @@ def train(opt):
 
     """ setup loss """
     if 'CTC' in opt.Prediction:
-        criterion = torch.nn.CTCLoss(zero_infinity=True).to(device)
+        if opt.baiduCTC:
+            # need to install warpctc. see our guideline.
+            from warpctc_pytorch import CTCLoss 
+            criterion = CTCLoss()
+        else:
+            criterion = torch.nn.CTCLoss(zero_infinity=True).to(device)
     else:
         criterion = torch.nn.CrossEntropyLoss(ignore_index=0).to(device)  # ignore [GO] token = ignore index 0
     # loss averager
@@ -144,8 +152,12 @@ def train(opt):
         if 'CTC' in opt.Prediction:
             preds = model(image, text)
             preds_size = torch.IntTensor([preds.size(1)] * batch_size)
-            preds = preds.log_softmax(2).permute(1, 0, 2)
-            cost = criterion(preds, text, preds_size, length)
+            if opt.baiduCTC:
+                preds = preds.permute(1, 0, 2)  # to use CTCLoss format
+                cost = criterion(preds, text, preds_size, length) / batch_size
+            else:
+                preds = preds.log_softmax(2).permute(1, 0, 2)
+                cost = criterion(preds, text, preds_size, length)
 
         else:
             preds = model(image, text[:, :-1])  # align with Attention.forward
@@ -232,6 +244,7 @@ if __name__ == '__main__':
     parser.add_argument('--rho', type=float, default=0.95, help='decay rate rho for Adadelta. default=0.95')
     parser.add_argument('--eps', type=float, default=1e-8, help='eps for Adadelta. default=1e-8')
     parser.add_argument('--grad_clip', type=float, default=5, help='gradient clipping value. default=5')
+    parser.add_argument('--baiduCTC', action='store_true', help='for data_filtering_off mode')
     """ Data processing """
     parser.add_argument('--select_data', type=str, default='MJ-ST',
                         help='select training data (default is MJ-ST, which means MJ and ST used as training data)')

--- a/utils.py
+++ b/utils.py
@@ -52,6 +52,53 @@ class CTCLabelConverter(object):
         return texts
 
 
+class CTCLabelConverterForBaiduWarpctc(object):
+    """ Convert between text-label and text-index for baidu warpctc """
+
+    def __init__(self, character):
+        # character (str): set of the possible characters.
+        dict_character = list(character)
+
+        self.dict = {}
+        for i, char in enumerate(dict_character):
+            # NOTE: 0 is reserved for 'CTCblank' token required by CTCLoss
+            self.dict[char] = i + 1
+
+        self.character = ['[CTCblank]'] + dict_character  # dummy '[CTCblank]' token for CTCLoss (index 0)
+
+    def encode(self, text, batch_max_length=25):
+        """convert text-label into text-index.
+        input:
+            text: text labels of each image. [batch_size]
+        output:
+            text: concatenated text index for CTCLoss.
+                    [sum(text_lengths)] = [text_index_0 + text_index_1 + ... + text_index_(n - 1)]
+            length: length of each text. [batch_size]
+        """
+        length = [len(s) for s in text]
+        text = ''.join(text)
+        text = [self.dict[char] for char in text]
+
+        return (torch.IntTensor(text), torch.IntTensor(length))
+
+    def decode(self, text_index, length):
+        """ convert text-index into text-label. """
+        texts = []
+        index = 0
+        for l in length:
+            t = text_index[index:index + l]
+
+            char_list = []
+            for i in range(l):
+                if t[i] != 0 and (not (i > 0 and t[i - 1] == t[i])):  # removing repeated characters and blank.
+                    char_list.append(self.character[t[i]])
+            text = ''.join(char_list)
+
+            texts.append(text)
+            index += l
+        return texts
+
+
 class AttnLabelConverter(object):
     """ Convert between text-label and text-index """
 


### PR DESCRIPTION
While we used Baidu warpctc in the paper, we use PyTorch CTC in this repository. 
The main reason why we changed the Baidu warpctc into PyTorch CTC is that Baidu warpctc is not easy to use for PyTorch >= 1.2 (see [here](https://github.com/espnet/espnet/blob/2115094a20527fdf27fbda3704cbdae1539f0cba/tools/installers/install_warp-ctc.sh#L58)).
(our initial codes used Baidu warpctc before PyTorch CTC was released.)

However, we found that the accuracy of PyTorch CTC apparently lower than Baidu warpctc in some results (ex. CRNN, about 1%).
And thus, reproducing the CRNN result of our paper was difficult.
This problem is related to PyTorch version and Baidu warpctc issue. 
Sorry for the inconvenience.

To solve this problem, 
1. We provide a guideline to reproduce our paper by using PyTorch 1.1 and Baidu warpctc.
2. We also upload the pretrained model [CRNN-PyTorchCTC.pth](https://drive.google.com/file/d/1tEt_4WFpQg_vozIIVnY-9TNcClgN7R-H/view?usp=sharing) (trained with the default setting of this repo which uses PyTorch CTCLoss) and report the result of this model here.

The details are below.

1. Guideline to reproduce our paper by using PyTorch 1.1 and Baidu warpctc.
```
# we recommend using conda. If you don’t use conda, just ignore the first 3 lines.
conda create -n warpctc python=3.6
conda activate warpctc
conda install ipython
pip install torch==1.1
pip install warpctc-pytorch11-cuda90
pip install lmdb pillow torchvision==0.4 nltk natsort
```
Then run the train.py with `--baiduCTC` option as below.
```
CUDA_VISIBLE_DEVICES=0 python3 train.py \
--train_data data_lmdb_release/training --valid_data data_lmdb_release/validation --select_data MJ-ST --batch_ratio 0.5-0.5 \
--Transformation None --FeatureExtraction VGG --SequenceModeling BiLSTM --Prediction CTC \
--exp_name CRNN-baiduCTC --baiduCTC
```

If the current_accuracy at 2000 iter is about 48\~50%, Baidu warpctc is working right.
In the case of PyTorch CTCLoss, the current_accuracy at 2000 iter is about 45\~46%.

We upload the pretrained model [CRNN-BaiduCTC.pth](https://drive.google.com/file/d/1QXD0Ag9TgiuqgBPLTOxoh_67M212O5X1/view?usp=sharing) (trained with `--baiduCTC` option which uses Baidu warpctc) and report the result of this model here.

```
IIIT5k_3000: 82.300	SVT: 82.844
IC03_860: 92.674	IC03_867: 92.849
IC13_857: 90.548	IC13_1015: 88.670	
IC15_1811: 69.244	IC15_2077: 63.746	
SVTP: 70.698		CUTE80: 62.500

Total accuracy of a unified evaluation dataset (8,539 images in total) is 78.112;
3,000 from IIIT, 647 from SVT, 867 from IC03, 1015 from IC13, 2,077 from IC15, 645 from SP, and 288 from CT.
```


2. We also upload the pretrained model [CRNN-PyTorchCTC.pth](https://drive.google.com/file/d/1tEt_4WFpQg_vozIIVnY-9TNcClgN7R-H/view?usp=sharing) (trained with the default setting of this repo which uses PyTorch CTCLoss) and report the result of this model here.

```
IIIT5k_3000: 82.567	SVT: 80.526
IC03_860: 92.791	IC03_867: 92.272
IC13_857: 89.732	IC13_1015: 88.768
IC15_1811: 66.317	IC15_2077: 61.387
SVTP: 65.736		CUTE80: 64.931

Total accuracy of a unified evaluation dataset (8,539 images in total) is 77.117;
3,000 from IIIT, 647 from SVT, 867 from IC03, 1015 from IC13, 2,077 from IC15, 645 from SP, and 288 from CT.
```
The results could be slightly different up to random seed, your computing environment, and etc.

Hope this model/result helps your project.

If you have found some issue, please let us know.
Best.
