### PR TITLE
Update demo.py

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
 
     """ vocab / character number configuration """
     if opt.sensitive:
-        opt.character = string.printable[:-6]  # same with ASTER setting (use 94 char).
+        opt.character = string.printable[:-38]  # same with ASTER setting (use 94 char).
 
     cudnn.benchmark = True
     cudnn.deterministic = True


### PR DESCRIPTION
string.printable[:,-38] will keep 0-9, then a-z and A-Z as our opt.character