### PR TITLE
Add map location to torch.load when loading saved model

### DIFF
--- a/train.py
+++ b/train.py
@@ -81,9 +81,9 @@ def train(opt):
     if opt.saved_model != '':
         print(f'loading pretrained model from {opt.saved_model}')
         if opt.FT:
-            model.load_state_dict(torch.load(opt.saved_model), strict=False)
+            model.load_state_dict(torch.load(opt.saved_model, map_location=device), strict=False)
         else:
-            model.load_state_dict(torch.load(opt.saved_model))
+            model.load_state_dict(torch.load(opt.saved_model, map_location=device))
     print("Model:")
     print(model)
 


### PR DESCRIPTION
When loading pretrained weights from Drive, they are allocated on GPU, but if one wants to load them on CPU, they get an error. So I propose fixing this error by adding "map_location=device" to torch.load in train.py