### PR TITLE
Fix utils.py for preventing KeyError at self.dict[char]

### DIFF
--- a/train.py
+++ b/train.py
@@ -80,8 +80,14 @@ def train(opt):
     model.train()
     if opt.saved_model != '':
         print(f'loading pretrained model from {opt.saved_model}')
+        # Fine tunning 목적
         if opt.FT:
-            model.load_state_dict(torch.load(opt.saved_model), strict=False)
+            checkpoint = torch.load(opt.saved_model)
+            checkpoint = {k: v for k, v in checkpoint.items() if (k in model.state_dict().keys()) and (model.state_dict()[k].shape == checkpoint[k].shape)}
+            for name in model.state_dict().keys() :
+                if name in checkpoint.keys() :
+                    model.state_dict()[name].copy_(checkpoint[name])
+            #model.load_state_dict(torch.load(opt.saved_model), strict=False)
         else:
             model.load_state_dict(torch.load(opt.saved_model))
     print("Model:")

--- a/utils.py
+++ b/utils.py
@@ -32,8 +32,20 @@ class CTCLabelConverter(object):
         batch_text = torch.LongTensor(len(text), batch_max_length).fill_(0)
         for i, t in enumerate(text):
             text = list(t)
-            text = [self.dict[char] for char in text]
-            batch_text[i][:len(text)] = torch.LongTensor(text)
+            # Could occur Dict Key Error. So, should check 'char' in self.dict.
+            # If there isn't char in self.dict, it will be ignored.
+            # Should drop all data including that char. because it could make train worse.
+            text_index = []
+            for char in text:
+                if char not in self.dict:
+                    text_index = []
+                    break
+                text_index.append(self.dict[char])
+
+            batch_text[i][:len(text_index)] = torch.LongTensor(text_index)
+
+            #text = [self.dict[char] for char in text if char in self.dict]
+            #batch_text[i][:len(text)] = torch.LongTensor(text)
         return (batch_text.to(device), torch.IntTensor(length).to(device))
 
     def decode(self, text_index, length):


### PR DESCRIPTION
And improving training quality. 

It's weird to get the character from opt.character and get the train's GroundTruth directly without any filtering. You should check it at least once.

Can occur KeyError
<img width="640" alt="image" src="https://github.com/clovaai/deep-text-recognition-benchmark/assets/24960675/92bd6628-9cb3-4d83-97af-cc725169c5ae">

So, you can think that if you change
'text = [self.dict[char] for char in text]'
into 'text = [self.dict[char] for char in text if char in self.dict]', problem will solve
but there is a possibility of mislearning.

Should drop all data including that char. because it could make train worse.

So I change the code like that